### PR TITLE
Remove needless registry key

### DIFF
--- a/FlexConfirmMail.iss
+++ b/FlexConfirmMail.iss
@@ -31,7 +31,6 @@ Root: HKLM32; Subkey: "Software\Microsoft\Office\Outlook\Addins\FlexConfirmMail"
 
 ; Prevent Outlook from disabling .NET addon
 Root: HKCU; Subkey: "Software\Microsoft\Office\16.0\Outlook\Resiliency\DoNotDisableAddinList"; ValueType: dword; ValueName: "FlexConfirmMail"; ValueData: 1
-Root: HKCU; Subkey: "Software\Microsoft\Office\13.0\Outlook\Resiliency\DoNotDisableAddinList"; ValueType: dword; ValueName: "FlexConfirmMail"; ValueData: 1
 
 [Languages]
 Name: en; MessagesFile: "compiler:Default.isl"


### PR DESCRIPTION
FlexConfirmMail supports Outlook 2016+, so we need add registry keys only for `Software\Microsoft\Office\16.0`.
Also, Office skips the internal version "13", so there is no Office version corresponding to `Software\Microsoft\Office\13.0`.
(I didn't find the primary source though...)

https://web.archive.org/web/20090513124655/http://www.computerworld.jp/news/sw/58333.html
https://ja.wikipedia.org/wiki/Microsoft_Office

## Test

* [x] Confirm that the installer works fine
* [x]  Confirm that the registry key `HKEY_CURRENT_USER\Software\Microsoft\Office\13.0\Outlook\Resiliency\DoNotDisableAddinList` does not exist
* [x]  Confirm that the values of the registry key `HKEY_CURRENT_USER\Software\Microsoft\Office\16.0\Outlook\Resiliency\DoNotDisableAddinList` contains `FlexConfirmMail`