### PR TITLE
Modify default language to en

### DIFF
--- a/FlexConfirmMail.csproj
+++ b/FlexConfirmMail.csproj
@@ -190,7 +190,7 @@
     <Compile Include="Ribbon.cs" />
     <EmbeddedResource Include="Properties\Resources.es.resx" />
     <EmbeddedResource Include="Properties\Resources.zh.resx" />
-    <EmbeddedResource Include="Properties\Resources.en.resx" />
+    <EmbeddedResource Include="Properties\Resources.ja.resx" />
     <EmbeddedResource Include="Properties\Resources.resx">
       <Generator>PublicResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>

--- a/FlexConfirmMail.iss
+++ b/FlexConfirmMail.iss
@@ -40,7 +40,7 @@ Name: jp; MessagesFile: "compiler:Languages\Japanese.isl"
 Source: "bin\Release\FlexConfirmMail.dll"; DestDir: "{app}"; Flags: ignoreversion
 Source: "bin\Release\FlexConfirmMail.dll.manifest"; DestDir: "{app}"; Flags: ignoreversion
 Source: "bin\Release\FlexConfirmMail.vsto"; DestDir: "{app}"; Flags: ignoreversion
-Source: "bin\Release\en\FlexConfirmMail.resources.dll"; DestDir: "{app}\en"; Flags: ignoreversion
+Source: "bin\Release\ja\FlexConfirmMail.resources.dll"; DestDir: "{app}\ja"; Flags: ignoreversion
 Source: "bin\Release\zh\FlexConfirmMail.resources.dll"; DestDir: "{app}\zh"; Flags: ignoreversion
 Source: "bin\Release\es\FlexConfirmMail.resources.dll"; DestDir: "{app}\es"; Flags: ignoreversion
 Source: "bin\Release\Microsoft.Office.Tools.Common.v4.0.Utilities.dll"; DestDir: "{app}"; Flags: ignoreversion

--- a/Properties/Resources.ja.resx
+++ b/Properties/Resources.ja.resx
@@ -125,98 +125,98 @@
     <value>..\Resources\logo.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
   <data name="RibbonButtonFlexConfirmMail" xml:space="preserve">
-    <value>FlexConfirmMail Options</value>
+    <value>FlexConfirmMail設定</value>
   </data>
   <data name="RibbonGroupFlexConfirmMail" xml:space="preserve">
-    <value>Check</value>
+    <value>送信チェック</value>
   </data>
   <data name="SaveAndQuit" xml:space="preserve">
-    <value>Save and Exit</value>
+    <value>保存して閉じる</value>
   </data>
   <data name="Cancel" xml:space="preserve">
-    <value>Cancel</value>
+    <value>キャンセル</value>
   </data>
   <data name="Seconds" xml:space="preserve">
-    <value>seconds</value>
+    <value>秒</value>
   </data>
   <data name="ConfigWindowTitle" xml:space="preserve">
-    <value>FlexConfirmMail Options</value>
+    <value>FlexConfirmMail設定</value>
   </data>
   <data name="ConfigGeneral" xml:space="preserve">
-    <value>General</value>
+    <value>一般設定</value>
   </data>
   <data name="ConfigCount" xml:space="preserve">
-    <value>Countdown</value>
+    <value>送信カウントダウン設定</value>
   </data>
   <data name="ConfigCountEnabled" xml:space="preserve">
-    <value>Show a countdown clock when sending a message</value>
+    <value>メール送信前のカウントダウンを有効化する</value>
   </data>
   <data name="ConfigCountAllowSkip" xml:space="preserve">
-    <value>Show "Send Now" button in the countdown dialog</value>
+    <value>カウントダウンのダイアログの「いますぐ送信」ボタンを有効化する</value>
   </data>
   <data name="ConfigCountSeconds" xml:space="preserve">
-    <value>Delay sending a message by</value>
+    <value>送信までのカウントダウン秒数:</value>
   </data>
   <data name="ConfigWarning" xml:space="preserve">
-    <value>To/Cc</value>
+    <value>警告設定</value>
   </data>
   <data name="ConfigSafeBccEnabled" xml:space="preserve">
-    <value>Enable "too many domains in To/Cc fields" warnings</value>
+    <value>To/CCに一定数以上のドメインが含まれている場合に警告する</value>
   </data>
   <data name="ConfigSafeBccThreshold" xml:space="preserve">
-    <value>Warn if To/Cc fields contain</value>
+    <value>警告対象となるドメインの数:</value>
   </data>
   <data name="ConfigSafeBccThresholdSuffix" xml:space="preserve">
-    <value>domains (or more)</value>
+    <value>件以上</value>
   </data>
   <data name="ConfigMisc" xml:space="preserve">
-    <value>Miscellaneous</value>
+    <value>その他の設定</value>
   </data>
   <data name="ConfigMainSkipIfNoExt" xml:space="preserve">
-    <value>Skip confirmation if all the recpients are trusted.</value>
+    <value>宛先が社内のみの場合は確認をスキップする</value>
   </data>
   <data name="ConfigTrustedDomains" xml:space="preserve">
-    <value>Configure Trusted Domains and Addresses</value>
+    <value>社内ドメイン・アドレス設定</value>
   </data>
   <data name="TrustedDomainsPolicy" xml:space="preserve">
-    <value># Trusted Domains and Addresses ###
-# The following domains and addresses are trusted by Group Policy.
+    <value># 社内ドメイン・アドレス設定 ###
+# 組織設定により、社内ドメイン・アドレスとして以下が指定されています。
 #
 # {0}
 #
-# To add more domains or addresses, input entries (one per line) below.
-# You can also exclude domains or addresses by adding "-" at the beginning.
-# And wildcards (* and ?) are also available.
-# When an entry contains @, the entry is regarded as address.
-# When an entry does not contains @, the entry is regarded as domain.
+# さらにドメイン・アドレスを追加する場合は、以下に1行ずつ入力してください。
+# また、先頭に「-」をつけると、ドメイン・アドレスを除外することができます。
+# 指定にはワイルドカード（*および?）も使用可能です。
+# @を含む場合はアドレスが指定されたとみなします。
+# @を含まない場合はドメインが指定されたとみなします。
 ##################################
 
 {1}</value>
   </data>
   <data name="UnsafeDomainsPolicy" xml:space="preserve">
-    <value># Unsafe Domains and Addresses ###
-# The following domains and addresses are considered unsafe by Group Policy.
+    <value># 注意が必要なドメイン・アドレス設定 ###
+# 組織設定により、注意が必要なドメイン・アドレスとして以下が指定されています。
 #
 # {0}
 #
-# To add more domains or addresses, input entries (one per line) below.
-# You can also exclude domains or addresses by adding "-" at the beginning.
-# And wildcards (* and ?) are also available.
-# When an entry contains @, the entry is regarded as address.
-# When an entry does not contains @, the entry is regarded as domain.
+# さらにドメイン・アドレスを追加する場合は、以下に1行ずつ入力してください。
+# また、先頭に「-」をつけると、ドメイン・アドレスを除外することができます。
+# 指定にはワイルドカード（*および?）も使用可能です。
+# @を含む場合はアドレスが指定されたとみなします。
+# @を含まない場合はドメインが指定されたとみなします。
 ##################################
 
 {1}</value>
   </data>
   <data name="UnsafeFilesPolicy" xml:space="preserve">
-    <value># Unsafe Files ###
-# The following keywords are considered unsafe by Group Policy.
+    <value># 注意が必要なファイル名設定 ###
+# 組織設定により、注意が必要なファイル名として以下が指定されています。
 #
 # {0}
 #
-# To add more keywords, input entries (one per line) below.
-# You can also exclude keywords by adding "-" at the beginning.
-# And wildcards (* and ?) are also available.
+# さらにキーワードを追加する場合は、以下に1行ずつ入力してください。
+# また、先頭に「-」をつけると、キーワードを除外することができます。
+# 指定にはワイルドカード（*および?）も使用可能です。
 ##################################
 
 {1}</value>
@@ -230,18 +230,18 @@
 -example.org</value>
   </data>
   <data name="UnsafeFilesExample" xml:space="preserve">
-    <value>Confidential
--ExcludedItem</value>
+    <value>社外秘
+-除外キーワード</value>
   </data>
   <data name="TrustedDomainsTemplate" xml:space="preserve">
-    <value># Trusted Domains and Addresses ###
+    <value># 社内ドメイン・アドレス設定 ###
 #
-# (1) Set the list of domains and addresses to be treated as internal ones.
-# (2) Enter one entry per line as follows.
-# (3) Lines starting with # are ignored.
-# (4) Wildcards (* and ?) are available.
-# (5) When an entry contains @, the entry is regarded as address.
-# (6) When an entry does not contains @, the entry is regarded as domain.
+# (1) 送信時に社内の宛先として扱うドメイン・アドレスを指定します。
+# (2) 以下の例のように一行に一件ずつ記載します。
+# (3) 冒頭が「#」から始まる行は無視されます。
+# (4) 指定にはワイルドカード（*および?）を使用可能です。
+# (5) @を含む場合はアドレスが指定されたとみなします。
+# (6) @を含まない場合はドメインが指定されたとみなします。
 #
 ##################################
 
@@ -249,14 +249,14 @@ example.com
 example.org</value>
   </data>
   <data name="UnsafeDomainsTemplate" xml:space="preserve">
-    <value># Unsafe Domains and Addresses ###
+    <value># 注意が必要なドメイン・アドレス設定 ###
 #
-# (1) Set the list of domains and addresses to show an "unsafe recipient" warning.
-# (2) Enter one entry per line as follows.
-# (3) Lines starting with # are ignored.
-# (4) Wildcards (* and ?) are available.
-# (5) When an entry contains @, the entry is regarded as address.
-# (6) When an entry does not contains @, the entry is regarded as domain.
+# (1) 送信時に警告対象とする注意ドメイン・アドレスを指定します。
+# (2) 以下の例のように一行に一件ずつ記載します。
+# (3) 冒頭が「#」から始まる行は無視されます。
+# (4) 指定にはワイルドカード（*および?）を使用可能です。
+# (5) @を含む場合はアドレスが指定されたとみなします。
+# (6) @を含まない場合はドメインが指定されたとみなします。
 #
 ##################################
 
@@ -264,105 +264,105 @@ example.com
 example.org</value>
   </data>
   <data name="UnsafeFilesTemplate" xml:space="preserve">
-    <value># Unsafe Files ###
+    <value># 注意が必要なファイル名設定 ###
 #
-# (1) Set the list of keywords to show an "unsafe filename" warning.
-# (2) Enter one entry per line as follows.
-# (3) Lines starting with # are ignored.
-# (4) Wildcards (* and ?) are available.
+# (1) 添付ファイルに含まれる場合に警告する注意ワードを指定します。
+# (2) 以下の例のように一行に一件ずつ記載します。
+# (3) 冒頭が「#」から始まる行は無視されます。
 #
 ##################################
 
-secret
-confidential
-</value>
+社外秘
+機密</value>
   </data>
   <data name="TrustedDomains" xml:space="preserve">
-    <value>Trusted Domains and Addresses</value>
+    <value>社内ドメイン・アドレス</value>
   </data>
   <data name="ConfigUnsafeDomains" xml:space="preserve">
-    <value>Configure Unsafe Domains and Addresses</value>
+    <value>注意が必要なドメイン・アドレス設定</value>
   </data>
   <data name="UnsafeDomains" xml:space="preserve">
-    <value>Unsafe Domains and Addresses</value>
+    <value>注意が必要なドメイン・アドレス</value>
   </data>
   <data name="ConfigUnsafeFiles" xml:space="preserve">
-    <value>Configure Unsafe Files</value>
+    <value>注意が必要なファイル名設定</value>
   </data>
   <data name="UnsafeFiles" xml:space="preserve">
-    <value>Unsafe Files</value>
+    <value>注意が必要なファイル名</value>
   </data>
   <data name="AboutAddon" xml:space="preserve">
-    <value>Version</value>
+    <value>このアドオンについて</value>
   </data>
   <data name="TextLog" xml:space="preserve">
-    <value>App Logs</value>
+    <value>動作ログ</value>
   </data>
   <data name="CountWindowTitle" xml:space="preserve">
-    <value>Countdown - FlexConfirmMail</value>
+    <value>送信カウントダウン - FlexConfirmMail</value>
   </data>
   <data name="CountSendInSeconds" xml:space="preserve">
-    <value>seconds to send</value>
+    <value>秒後に送信します</value>
   </data>
   <data name="Send" xml:space="preserve">
-    <value>Send</value>
+    <value>送信</value>
   </data>
   <data name="SendNow" xml:space="preserve">
-    <value>Send Now</value>
+    <value>今すぐ送信</value>
   </data>
   <data name="MainExternal" xml:space="preserve">
-    <value>External Recipients</value>
+    <value>外部の送信先</value>
   </data>
   <data name="MainUnsafeDomainsWarning" xml:space="preserve">
-    <value>[Warn] An unsafe domain "{0}" found in the recipient list</value>
+    <value>[警告] 注意が必要なドメイン（{0}）が宛先に含まれています。</value>
   </data>
   <data name="MainUnsafeDomainsWarningHint" xml:space="preserve">
-    <value>This domain is registered as unsafe. Please recheck and confirm.</value>
+    <value>このドメインは誤送信の可能性が高いため、再確認を促す警告を出してします。</value>
   </data>
   <data name="MainUnsafeFilesWarning" xml:space="preserve">
-    <value>[Warn] An unsafe keyword ({0}) found in the attachment list</value>
+    <value>[警告] 注意が必要なファイル名（{0}）が含まれています。</value>
   </data>
   <data name="MainUnsafeFilesWarningHint" xml:space="preserve">
-    <value>This filename is registered as unsafe. Please recheck and confirm.</value>
+    <value>添付ファイルに注意が必要な単語が含まれているため、
+再確認を促す警告を出しています。</value>
   </data>
   <data name="MainSafeBccWarning" xml:space="preserve">
-    <value>[Warn] To/Cc fields contain no less than {0} domains</value>
+    <value>[警告] To・Ccに{0}件以上のドメインが含まれています。</value>
   </data>
   <data name="MainSafeBccWarningHint" xml:space="preserve">
-    <value>Beware that To/Cc fields are visible to any recipients,
-so please use Bcc when sending an message to unrelated parties.</value>
-  </data>
-  <data name="MainTrusted" xml:space="preserve">
-    <value>Internal Recipients</value>
-  </data>
-  <data name="MainCheckAll" xml:space="preserve">
-    <value>Check all</value>
+    <value>宛先に多数のドメインが検知されました。
+ToおよびCcに含まれるメールアドレスはすべての受取人が確認できるため、
+アナウンスなどを一斉送信する場合はBccを利用して宛先リストを隠します。</value>
   </data>
   <data name="MainFilesWarning" xml:space="preserve">
-    <value>[Attachment] {0}</value>
+    <value>[添付ファイル] {0}</value>
+  </data>
+  <data name="MainTrusted" xml:space="preserve">
+    <value>社内の送信先</value>
+  </data>
+  <data name="MainCheckAll" xml:space="preserve">
+    <value>一括チェック</value>
   </data>
   <data name="MainFile" xml:space="preserve">
-    <value>Attachments / Warnings</value>
+    <value>添付ファイル／その他の警告</value>
   </data>
   <data name="ConfigSafeNewDomainsEnabled" xml:space="preserve">
-    <value>Confirm when any recipients with domains different from any existing recipients are added</value>
+    <value>返信の宛先に今まで含まれていなかったドメインのアドレスが追加された場合に警告する</value>
   </data>
   <data name="ConfirmNewDomainsBody1" xml:space="preserve">
-    <value>There are recipients with domains not included in the recipients of the original message.</value>
+    <value>返信元のメールの宛先に含まれていなかったドメインの以下の宛先が追加されています。</value>
   </data>
   <data name="NewDomainDialogTitle" xml:space="preserve">
-    <value>Warning  - FlexConfirmMail</value>
+    <value>警告 - FlexConfirmMail</value>
   </data>
   <data name="ConfirmNewDomainsBody2" xml:space="preserve">
-    <value>Do you really want to send this message?</value>
+    <value>送信してよろしいですか？</value>
   </data>
-  <data name="Warrning" xml:space="preserve">
-    <value>Warning!</value>
+  <data name="Warning" xml:space="preserve">
+    <value>⨉ 警告！</value>
   </data>
   <data name="MainUnsafeAddressesWarning" xml:space="preserve">
-    <value>[Warn] An unsafe address "{0}" found in the recipient list</value>
+    <value>[警告] 注意が必要なアドレス（{0}）が宛先に含まれています。</value>
   </data>
   <data name="MainUnsafeAddressesWarningHint" xml:space="preserve">
-    <value>This address is registered as unsafe. Please recheck and confirm.</value>
+    <value>このアドレスは誤送信の可能性が高いため、再確認を促す警告を出してします。</value>
   </data>
 </root>

--- a/Properties/Resources.resx
+++ b/Properties/Resources.resx
@@ -125,98 +125,98 @@
     <value>..\Resources\logo.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
   <data name="RibbonButtonFlexConfirmMail" xml:space="preserve">
-    <value>FlexConfirmMail設定</value>
+    <value>FlexConfirmMail Options</value>
   </data>
   <data name="RibbonGroupFlexConfirmMail" xml:space="preserve">
-    <value>送信チェック</value>
+    <value>Check</value>
   </data>
   <data name="SaveAndQuit" xml:space="preserve">
-    <value>保存して閉じる</value>
+    <value>Save and Exit</value>
   </data>
   <data name="Cancel" xml:space="preserve">
-    <value>キャンセル</value>
+    <value>Cancel</value>
   </data>
   <data name="Seconds" xml:space="preserve">
-    <value>秒</value>
+    <value>seconds</value>
   </data>
   <data name="ConfigWindowTitle" xml:space="preserve">
-    <value>FlexConfirmMail設定</value>
+    <value>FlexConfirmMail Options</value>
   </data>
   <data name="ConfigGeneral" xml:space="preserve">
-    <value>一般設定</value>
+    <value>General</value>
   </data>
   <data name="ConfigCount" xml:space="preserve">
-    <value>送信カウントダウン設定</value>
+    <value>Countdown</value>
   </data>
   <data name="ConfigCountEnabled" xml:space="preserve">
-    <value>メール送信前のカウントダウンを有効化する</value>
+    <value>Show a countdown clock when sending a message</value>
   </data>
   <data name="ConfigCountAllowSkip" xml:space="preserve">
-    <value>カウントダウンのダイアログの「いますぐ送信」ボタンを有効化する</value>
+    <value>Show "Send Now" button in the countdown dialog</value>
   </data>
   <data name="ConfigCountSeconds" xml:space="preserve">
-    <value>送信までのカウントダウン秒数:</value>
+    <value>Delay sending a message by</value>
   </data>
   <data name="ConfigWarning" xml:space="preserve">
-    <value>警告設定</value>
+    <value>To/Cc</value>
   </data>
   <data name="ConfigSafeBccEnabled" xml:space="preserve">
-    <value>To/CCに一定数以上のドメインが含まれている場合に警告する</value>
+    <value>Enable "too many domains in To/Cc fields" warnings</value>
   </data>
   <data name="ConfigSafeBccThreshold" xml:space="preserve">
-    <value>警告対象となるドメインの数:</value>
+    <value>Warn if To/Cc fields contain</value>
   </data>
   <data name="ConfigSafeBccThresholdSuffix" xml:space="preserve">
-    <value>件以上</value>
+    <value>domains (or more)</value>
   </data>
   <data name="ConfigMisc" xml:space="preserve">
-    <value>その他の設定</value>
+    <value>Miscellaneous</value>
   </data>
   <data name="ConfigMainSkipIfNoExt" xml:space="preserve">
-    <value>宛先が社内のみの場合は確認をスキップする</value>
+    <value>Skip confirmation if all the recpients are trusted.</value>
   </data>
   <data name="ConfigTrustedDomains" xml:space="preserve">
-    <value>社内ドメイン・アドレス設定</value>
+    <value>Configure Trusted Domains and Addresses</value>
   </data>
   <data name="TrustedDomainsPolicy" xml:space="preserve">
-    <value># 社内ドメイン・アドレス設定 ###
-# 組織設定により、社内ドメイン・アドレスとして以下が指定されています。
+    <value># Trusted Domains and Addresses ###
+# The following domains and addresses are trusted by Group Policy.
 #
 # {0}
 #
-# さらにドメイン・アドレスを追加する場合は、以下に1行ずつ入力してください。
-# また、先頭に「-」をつけると、ドメイン・アドレスを除外することができます。
-# 指定にはワイルドカード（*および?）も使用可能です。
-# @を含む場合はアドレスが指定されたとみなします。
-# @を含まない場合はドメインが指定されたとみなします。
+# To add more domains or addresses, input entries (one per line) below.
+# You can also exclude domains or addresses by adding "-" at the beginning.
+# And wildcards (* and ?) are also available.
+# When an entry contains @, the entry is regarded as address.
+# When an entry does not contains @, the entry is regarded as domain.
 ##################################
 
 {1}</value>
   </data>
   <data name="UnsafeDomainsPolicy" xml:space="preserve">
-    <value># 注意が必要なドメイン・アドレス設定 ###
-# 組織設定により、注意が必要なドメイン・アドレスとして以下が指定されています。
+    <value># Unsafe Domains and Addresses ###
+# The following domains and addresses are considered unsafe by Group Policy.
 #
 # {0}
 #
-# さらにドメイン・アドレスを追加する場合は、以下に1行ずつ入力してください。
-# また、先頭に「-」をつけると、ドメイン・アドレスを除外することができます。
-# 指定にはワイルドカード（*および?）も使用可能です。
-# @を含む場合はアドレスが指定されたとみなします。
-# @を含まない場合はドメインが指定されたとみなします。
+# To add more domains or addresses, input entries (one per line) below.
+# You can also exclude domains or addresses by adding "-" at the beginning.
+# And wildcards (* and ?) are also available.
+# When an entry contains @, the entry is regarded as address.
+# When an entry does not contains @, the entry is regarded as domain.
 ##################################
 
 {1}</value>
   </data>
   <data name="UnsafeFilesPolicy" xml:space="preserve">
-    <value># 注意が必要なファイル名設定 ###
-# 組織設定により、注意が必要なファイル名として以下が指定されています。
+    <value># Unsafe Files ###
+# The following keywords are considered unsafe by Group Policy.
 #
 # {0}
 #
-# さらにキーワードを追加する場合は、以下に1行ずつ入力してください。
-# また、先頭に「-」をつけると、キーワードを除外することができます。
-# 指定にはワイルドカード（*および?）も使用可能です。
+# To add more keywords, input entries (one per line) below.
+# You can also exclude keywords by adding "-" at the beginning.
+# And wildcards (* and ?) are also available.
 ##################################
 
 {1}</value>
@@ -230,18 +230,18 @@
 -example.org</value>
   </data>
   <data name="UnsafeFilesExample" xml:space="preserve">
-    <value>社外秘
--除外キーワード</value>
+    <value>Confidential
+-ExcludedItem</value>
   </data>
   <data name="TrustedDomainsTemplate" xml:space="preserve">
-    <value># 社内ドメイン・アドレス設定 ###
+    <value># Trusted Domains and Addresses ###
 #
-# (1) 送信時に社内の宛先として扱うドメイン・アドレスを指定します。
-# (2) 以下の例のように一行に一件ずつ記載します。
-# (3) 冒頭が「#」から始まる行は無視されます。
-# (4) 指定にはワイルドカード（*および?）を使用可能です。
-# (5) @を含む場合はアドレスが指定されたとみなします。
-# (6) @を含まない場合はドメインが指定されたとみなします。
+# (1) Set the list of domains and addresses to be treated as internal ones.
+# (2) Enter one entry per line as follows.
+# (3) Lines starting with # are ignored.
+# (4) Wildcards (* and ?) are available.
+# (5) When an entry contains @, the entry is regarded as address.
+# (6) When an entry does not contains @, the entry is regarded as domain.
 #
 ##################################
 
@@ -249,14 +249,14 @@ example.com
 example.org</value>
   </data>
   <data name="UnsafeDomainsTemplate" xml:space="preserve">
-    <value># 注意が必要なドメイン・アドレス設定 ###
+    <value># Unsafe Domains and Addresses ###
 #
-# (1) 送信時に警告対象とする注意ドメイン・アドレスを指定します。
-# (2) 以下の例のように一行に一件ずつ記載します。
-# (3) 冒頭が「#」から始まる行は無視されます。
-# (4) 指定にはワイルドカード（*および?）を使用可能です。
-# (5) @を含む場合はアドレスが指定されたとみなします。
-# (6) @を含まない場合はドメインが指定されたとみなします。
+# (1) Set the list of domains and addresses to show an "unsafe recipient" warning.
+# (2) Enter one entry per line as follows.
+# (3) Lines starting with # are ignored.
+# (4) Wildcards (* and ?) are available.
+# (5) When an entry contains @, the entry is regarded as address.
+# (6) When an entry does not contains @, the entry is regarded as domain.
 #
 ##################################
 
@@ -264,105 +264,105 @@ example.com
 example.org</value>
   </data>
   <data name="UnsafeFilesTemplate" xml:space="preserve">
-    <value># 注意が必要なファイル名設定 ###
+    <value># Unsafe Files ###
 #
-# (1) 添付ファイルに含まれる場合に警告する注意ワードを指定します。
-# (2) 以下の例のように一行に一件ずつ記載します。
-# (3) 冒頭が「#」から始まる行は無視されます。
+# (1) Set the list of keywords to show an "unsafe filename" warning.
+# (2) Enter one entry per line as follows.
+# (3) Lines starting with # are ignored.
+# (4) Wildcards (* and ?) are available.
 #
 ##################################
 
-社外秘
-機密</value>
+secret
+confidential
+</value>
   </data>
   <data name="TrustedDomains" xml:space="preserve">
-    <value>社内ドメイン・アドレス</value>
+    <value>Trusted Domains and Addresses</value>
   </data>
   <data name="ConfigUnsafeDomains" xml:space="preserve">
-    <value>注意が必要なドメイン・アドレス設定</value>
+    <value>Configure Unsafe Domains and Addresses</value>
   </data>
   <data name="UnsafeDomains" xml:space="preserve">
-    <value>注意が必要なドメイン・アドレス</value>
+    <value>Unsafe Domains and Addresses</value>
   </data>
   <data name="ConfigUnsafeFiles" xml:space="preserve">
-    <value>注意が必要なファイル名設定</value>
+    <value>Configure Unsafe Files</value>
   </data>
   <data name="UnsafeFiles" xml:space="preserve">
-    <value>注意が必要なファイル名</value>
+    <value>Unsafe Files</value>
   </data>
   <data name="AboutAddon" xml:space="preserve">
-    <value>このアドオンについて</value>
+    <value>Version</value>
   </data>
   <data name="TextLog" xml:space="preserve">
-    <value>動作ログ</value>
+    <value>App Logs</value>
   </data>
   <data name="CountWindowTitle" xml:space="preserve">
-    <value>送信カウントダウン - FlexConfirmMail</value>
+    <value>Countdown - FlexConfirmMail</value>
   </data>
   <data name="CountSendInSeconds" xml:space="preserve">
-    <value>秒後に送信します</value>
+    <value>seconds to send</value>
   </data>
   <data name="Send" xml:space="preserve">
-    <value>送信</value>
+    <value>Send</value>
   </data>
   <data name="SendNow" xml:space="preserve">
-    <value>今すぐ送信</value>
+    <value>Send Now</value>
   </data>
   <data name="MainExternal" xml:space="preserve">
-    <value>外部の送信先</value>
+    <value>External Recipients</value>
   </data>
   <data name="MainUnsafeDomainsWarning" xml:space="preserve">
-    <value>[警告] 注意が必要なドメイン（{0}）が宛先に含まれています。</value>
+    <value>[Warn] An unsafe domain "{0}" found in the recipient list</value>
   </data>
   <data name="MainUnsafeDomainsWarningHint" xml:space="preserve">
-    <value>このドメインは誤送信の可能性が高いため、再確認を促す警告を出してします。</value>
+    <value>This domain is registered as unsafe. Please recheck and confirm.</value>
   </data>
   <data name="MainUnsafeFilesWarning" xml:space="preserve">
-    <value>[警告] 注意が必要なファイル名（{0}）が含まれています。</value>
+    <value>[Warn] An unsafe keyword ({0}) found in the attachment list</value>
   </data>
   <data name="MainUnsafeFilesWarningHint" xml:space="preserve">
-    <value>添付ファイルに注意が必要な単語が含まれているため、
-再確認を促す警告を出しています。</value>
+    <value>This filename is registered as unsafe. Please recheck and confirm.</value>
   </data>
   <data name="MainSafeBccWarning" xml:space="preserve">
-    <value>[警告] To・Ccに{0}件以上のドメインが含まれています。</value>
+    <value>[Warn] To/Cc fields contain no less than {0} domains</value>
   </data>
   <data name="MainSafeBccWarningHint" xml:space="preserve">
-    <value>宛先に多数のドメインが検知されました。
-ToおよびCcに含まれるメールアドレスはすべての受取人が確認できるため、
-アナウンスなどを一斉送信する場合はBccを利用して宛先リストを隠します。</value>
-  </data>
-  <data name="MainFilesWarning" xml:space="preserve">
-    <value>[添付ファイル] {0}</value>
+    <value>Beware that To/Cc fields are visible to any recipients,
+so please use Bcc when sending an message to unrelated parties.</value>
   </data>
   <data name="MainTrusted" xml:space="preserve">
-    <value>社内の送信先</value>
+    <value>Internal Recipients</value>
   </data>
   <data name="MainCheckAll" xml:space="preserve">
-    <value>一括チェック</value>
+    <value>Check all</value>
+  </data>
+  <data name="MainFilesWarning" xml:space="preserve">
+    <value>[Attachment] {0}</value>
   </data>
   <data name="MainFile" xml:space="preserve">
-    <value>添付ファイル／その他の警告</value>
+    <value>Attachments / Warnings</value>
   </data>
   <data name="ConfigSafeNewDomainsEnabled" xml:space="preserve">
-    <value>返信の宛先に今まで含まれていなかったドメインのアドレスが追加された場合に警告する</value>
+    <value>Confirm when any recipients with domains different from any existing recipients are added</value>
   </data>
   <data name="ConfirmNewDomainsBody1" xml:space="preserve">
-    <value>返信元のメールの宛先に含まれていなかったドメインの以下の宛先が追加されています。</value>
+    <value>There are recipients with domains not included in the recipients of the original message.</value>
   </data>
   <data name="NewDomainDialogTitle" xml:space="preserve">
-    <value>警告 - FlexConfirmMail</value>
+    <value>Warning  - FlexConfirmMail</value>
   </data>
   <data name="ConfirmNewDomainsBody2" xml:space="preserve">
-    <value>送信してよろしいですか？</value>
+    <value>Do you really want to send this message?</value>
   </data>
-  <data name="Warning" xml:space="preserve">
-    <value>⨉ 警告！</value>
+  <data name="Warrning" xml:space="preserve">
+    <value>Warning!</value>
   </data>
   <data name="MainUnsafeAddressesWarning" xml:space="preserve">
-    <value>[警告] 注意が必要なアドレス（{0}）が宛先に含まれています。</value>
+    <value>[Warn] An unsafe address "{0}" found in the recipient list</value>
   </data>
   <data name="MainUnsafeAddressesWarningHint" xml:space="preserve">
-    <value>このアドレスは誤送信の可能性が高いため、再確認を促す警告を出してします。</value>
+    <value>This address is registered as unsafe. Please recheck and confirm.</value>
   </data>
 </root>


### PR DESCRIPTION
Modify default language to en.

* Rename `Resources.resx` -> `Resources.ja.resx`
* Rename `Resources.en.resx` -> `Resources.resx`
* Modify to install the ja resource in setup

## Test

How to change Outlook display language:

1. Select File tab
2. Select Option button
3. Select Language tab
4. Change display language
5. Restart Outlook

* [x] Confirm that if Outlook display language is Japanese, FlexConfirmMail uses Japanese.
* [x] Confirm that if Outlook display language is English, FlexConfirmMail uses English.
* [x] Confirm that if Outlook display language is Chinese, FlexConfirmMail uses Chinese
* [x] Confirm that if Outlook display language is Spanish, FlexConfirmMail uses Spanish.
* [x] Confirm that if Outlook display language is Deutsch, FlexConfirmMail uses **English**.

