### PR TITLE
Bump version of actions/upload-artifact

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Make Installer
         run: iscc.exe FlexConfirmMail.iss
       - name: Upload Installer
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Installer
           path: dest/*.exe


### PR DESCRIPTION
It is announced that the actions/upload-artifact@v3 will  be closing down by 2025-01-30. We need to migrate to v4.
https://github.com/actions/upload-artifact?tab=readme-ov-file#breaking-changes
https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md
