### PR TITLE
Avoid custom UI error

### DIFF
--- a/Ribbon.cs
+++ b/Ribbon.cs
@@ -44,7 +44,11 @@ namespace FlexConfirmMail
 
         public string GetCustomUI(string ribbonID)
         {
-            return GetResourceText("FlexConfirmMail.Ribbon.xml");
+            if (ribbonID == "Microsoft.Outlook.Explorer")
+            {
+                return GetResourceText("FlexConfirmMail.Ribbon.xml");
+            }
+            return "";
         }
 
         #endregion


### PR DESCRIPTION
This is a cherry-pick of https://github.com/FlexConfirmMail/Outlook-VSTO-Addin/pull/44 for the master branch.

Avoid custom UI error like below.

![image](https://github.com/user-attachments/assets/53f57f1f-b8bd-4f73-842f-2935fa56636f)

The "TabMail" tab exists only in the ribbon whose id is "Microsoft.Outlook.Explorer". So if we open a ribbon whose id is not "Microsoft.Outlook.Explorer", we may get a custom UI error like "TabMail" doesn't exist. The error is displayed when Outlook's setting "Options" -> "Advanced" -> "Show add-in user interface errors" ("オプション" -> "詳細設定" -> "アドイン ユーザー インターフェイスのエラーを表示する" in Japanese) is enabled.

This patch avoid that error by creating custom UI only when ribbonID is "Microsoft.Outlook.Explorer".

## Test

* Install (enable) FlexConfirmMail
* Open Outlook option
* Enable "Options" -> "Advanced" -> "Show add-in user interface errors" ("オプション" -> "詳細設定" -> "アドイン ユーザー インターフェイスのエラーを表示する") of Outlook
* Open Home tab
  * [x] Confirm that FlexConfirmMail icon is displayed
* Double clock a mail to popup new inspector
  * [x] Confirm that the dialog for "Custom UI runtime error" is not displayed

