### PR TITLE
Add support for 32bit OS

### DIFF
--- a/FlexConfirmMail.iss
+++ b/FlexConfirmMail.iss
@@ -12,7 +12,7 @@ SolidCompression=yes
 OutputDir=dest
 OutputBaseFilename=FlexConfirmMailSetup-{#SetupSetting("AppVersion")}
 VersionInfoDescription=FlexConfirmMailSetup
-ArchitecturesAllowed=x64
+ArchitecturesAllowed=x86compatible
 ArchitecturesInstallIn64BitMode=x64
 
 [Registry]


### PR DESCRIPTION
In order to work on 32bit Windows, we need to allow to install on 32bit Windows.

The addin itself still work on 32bit Windows, so what only we need is allowing to install on 32bit Windows.
