### PR TITLE
Process "-" operator correctly

### DIFF
--- a/Config/Config.cs
+++ b/Config/Config.cs
@@ -107,7 +107,7 @@ namespace FlexConfirmMail
             UnsafeFilesPattern = $"({string.Join("|", UnsafeFiles.Select(ConvertWildCardToRegex))})";
         }
 
-        private HashSet<string> GetHashSet(List<string> list)
+        private HashSet<string> GetHashSet(IEnumerable<string> list)
         {
             HashSet<string> ret = new HashSet<string>();
             HashSet<string> exclude = new HashSet<string>();

--- a/Config/Config.cs
+++ b/Config/Config.cs
@@ -95,16 +95,35 @@ namespace FlexConfirmMail
 
         public void RebuildPatterns()
         {
-            var trustedAddressList = TrustedDomains.Where(_ => _.Contains("@"));
-            var trustedDomainList = TrustedDomains.Where(_ => !_.Contains("@"));
-            var unsafeAddressList = UnsafeDomains.Where(_ => _.Contains("@"));
-            var unsafeDomainList = UnsafeDomains.Where(_ => !_.Contains("@"));
+            HashSet<string> trustedAddressList = GetHashSet(TrustedDomains.Where(_ => _.Contains("@")).ToList());
+            HashSet<string> trustedDomainList = GetHashSet(TrustedDomains.Where(_ => !_.Contains("@")).ToList());
+            HashSet<string> unsafeAddressList = GetHashSet(UnsafeDomains.Where(_ => _.Contains("@")).ToList());
+            HashSet<string> unsafeDomainList = GetHashSet(UnsafeDomains.Where(_ => !_.Contains("@")).ToList());
 
             TrustedDomainsPattern = $"^({string.Join("|", trustedDomainList.Select(ConvertWildCardToRegex))})$";
             TrustedAddressesPattern = $"^({string.Join("|", trustedAddressList.Select(ConvertWildCardToRegex))})$";
             UnsafeDomainsPattern = $"^({string.Join("|", unsafeDomainList.Select(ConvertWildCardToRegex))})$";
             UnsafeAddressesPattern = $"^({string.Join("|", unsafeAddressList.Select(ConvertWildCardToRegex))})$";
             UnsafeFilesPattern = $"({string.Join("|", UnsafeFiles.Select(ConvertWildCardToRegex))})";
+        }
+
+        private HashSet<string> GetHashSet(List<string> list)
+        {
+            HashSet<string> ret = new HashSet<string>();
+            HashSet<string> exclude = new HashSet<string>();
+            foreach (string entry in list)
+            {
+                if (entry.StartsWith("-"))
+                {
+                    exclude.Add(entry.Substring(1));
+                }
+                else
+                {
+                    ret.Add(entry);
+                }
+            }
+            ret.ExceptWith(exclude);
+            return ret;
         }
 
         private static string ConvertWildCardToRegex(string value)

--- a/Config/Config.cs
+++ b/Config/Config.cs
@@ -96,7 +96,7 @@ namespace FlexConfirmMail
         public void RebuildPatterns()
         {
             HashSet<string> trustedAddressList = GetHashSet(TrustedDomains.Where(_ => _.Contains("@")));
-            HashSet<string> trustedDomainList = GetHashSet(TrustedDomains.Where(_ => !_.Contains("@")).ToList());
+            HashSet<string> trustedDomainList = GetHashSet(TrustedDomains.Where(_ => !_.Contains("@")));
             HashSet<string> unsafeAddressList = GetHashSet(UnsafeDomains.Where(_ => _.Contains("@")).ToList());
             HashSet<string> unsafeDomainList = GetHashSet(UnsafeDomains.Where(_ => !_.Contains("@")).ToList());
 

--- a/Config/Config.cs
+++ b/Config/Config.cs
@@ -98,7 +98,7 @@ namespace FlexConfirmMail
             HashSet<string> trustedAddressList = GetHashSet(TrustedDomains.Where(_ => _.Contains("@")));
             HashSet<string> trustedDomainList = GetHashSet(TrustedDomains.Where(_ => !_.Contains("@")));
             HashSet<string> unsafeAddressList = GetHashSet(UnsafeDomains.Where(_ => _.Contains("@")));
-            HashSet<string> unsafeDomainList = GetHashSet(UnsafeDomains.Where(_ => !_.Contains("@")).ToList());
+            HashSet<string> unsafeDomainList = GetHashSet(UnsafeDomains.Where(_ => !_.Contains("@")));
 
             TrustedDomainsPattern = $"^({string.Join("|", trustedDomainList.Select(ConvertWildCardToRegex))})$";
             TrustedAddressesPattern = $"^({string.Join("|", trustedAddressList.Select(ConvertWildCardToRegex))})$";

--- a/Config/Config.cs
+++ b/Config/Config.cs
@@ -97,7 +97,7 @@ namespace FlexConfirmMail
         {
             HashSet<string> trustedAddressList = GetHashSet(TrustedDomains.Where(_ => _.Contains("@")));
             HashSet<string> trustedDomainList = GetHashSet(TrustedDomains.Where(_ => !_.Contains("@")));
-            HashSet<string> unsafeAddressList = GetHashSet(UnsafeDomains.Where(_ => _.Contains("@")).ToList());
+            HashSet<string> unsafeAddressList = GetHashSet(UnsafeDomains.Where(_ => _.Contains("@")));
             HashSet<string> unsafeDomainList = GetHashSet(UnsafeDomains.Where(_ => !_.Contains("@")).ToList());
 
             TrustedDomainsPattern = $"^({string.Join("|", trustedDomainList.Select(ConvertWildCardToRegex))})$";

--- a/Config/Config.cs
+++ b/Config/Config.cs
@@ -95,7 +95,7 @@ namespace FlexConfirmMail
 
         public void RebuildPatterns()
         {
-            HashSet<string> trustedAddressList = GetHashSet(TrustedDomains.Where(_ => _.Contains("@")).ToList());
+            HashSet<string> trustedAddressList = GetHashSet(TrustedDomains.Where(_ => _.Contains("@")));
             HashSet<string> trustedDomainList = GetHashSet(TrustedDomains.Where(_ => !_.Contains("@")).ToList());
             HashSet<string> unsafeAddressList = GetHashSet(UnsafeDomains.Where(_ => _.Contains("@")).ToList());
             HashSet<string> unsafeDomainList = GetHashSet(UnsafeDomains.Where(_ => !_.Contains("@")).ToList());

--- a/Dialog/MainDialog.xaml.cs
+++ b/Dialog/MainDialog.xaml.cs
@@ -108,25 +108,6 @@ namespace FlexConfirmMail.Dialog
             return _mail.HTMLBody.Contains($"cid:{item.FileName}");
         }
 
-        private HashSet<string> GetHashSet(List<string> list)
-        {
-            HashSet<string> ret = new HashSet<string>();
-            HashSet<string> exclude = new HashSet<string>();
-            foreach (string entry in list)
-            {
-                if (entry.StartsWith("-"))
-                {
-                    exclude.Add(entry.Substring(1));
-                }
-                else
-                {
-                    ret.Add(entry);
-                }
-            }
-            ret.ExceptWith(exclude);
-            return ret;
-        }
-
         private List<string> ToLower(List<string> list)
         {
             List<string> ret = new List<string>();
@@ -253,8 +234,6 @@ namespace FlexConfirmMail.Dialog
 
         private void CheckUnsafeFiles()
         {
-            HashSet<string> notsafe = GetHashSet(_config.UnsafeFiles);
-
             foreach (Outlook.Attachment item in _mail.Attachments)
             {
                 HashSet<string> seen = new HashSet<string>();


### PR DESCRIPTION
Currently items with the prefix `-` does not work same as the one on Thunderbird version. This should fix the incompatibility. I've tried with these steps:

1. Start Outlook (classic).
2. Configure FlexConfirmMail's "trusted domains" as:
   ```
   clear-code.com
   -clear-code.com
   ```
3. Try to send a message with a recipient "yuki@clear-code.com".
4. Confirm that it is listed in the "external addresses" field.
5. Cancel to send the message and go to the options page of FlexConfirmMail.
6. Remove the line `-clear-code.com` from trusted domains.
7. Try to send the message again.
8. Confirm that it is listed in the "internal addresses" field.