### PR TITLE
Process negative operator for files

### DIFF
--- a/Config/Config.cs
+++ b/Config/Config.cs
@@ -95,11 +95,11 @@ namespace FlexConfirmMail
 
         public void RebuildPatterns()
         {
-            TrustedAddressesPattern = $"^{ConvertListToMatcherRegex(TrustedDomains.Where(_ => _.Contains("@")))}$";
-            TrustedDomainsPattern = $"^{ConvertListToMatcherRegex(TrustedDomains.Where(_ => !_.Contains("@")))}$";
-            UnsafeAddressesPattern = $"^{ConvertListToMatcherRegex(UnsafeDomains.Where(_ => _.Contains("@")))}$";
-            UnsafeDomainsPattern = $"^{ConvertListToMatcherRegex(UnsafeDomains.Where(_ => !_.Contains("@")))}$";
-            UnsafeFilesPattern = ConvertListToMatcherRegex(UnsafeFiles);
+            TrustedAddressesPattern = $"^{ConvertToMatcherRegex(TrustedDomains.Where(_ => _.Contains("@")))}$";
+            TrustedDomainsPattern = $"^{ConvertToMatcherRegex(TrustedDomains.Where(_ => !_.Contains("@")))}$";
+            UnsafeAddressesPattern = $"^{ConvertToMatcherRegex(UnsafeDomains.Where(_ => _.Contains("@")))}$";
+            UnsafeDomainsPattern = $"^{ConvertToMatcherRegex(UnsafeDomains.Where(_ => !_.Contains("@")))}$";
+            UnsafeFilesPattern = ConvertToMatcherRegex(UnsafeFiles);
 
             QueueLogger.Log($"TrustedAddressesPattern = {TrustedAddressesPattern}");
             QueueLogger.Log($"TrustedDomainsPattern = {TrustedDomainsPattern}");

--- a/Config/Config.cs
+++ b/Config/Config.cs
@@ -108,7 +108,7 @@ namespace FlexConfirmMail
             QueueLogger.Log($"UnsafeFilesPattern = {UnsafeFilesPattern}");
         }
 
-        private static string ConvertListToMatcherRegex(IEnumerable<string> list)
+        private static string ConvertToMatcherRegex(IEnumerable<string> list)
         {
             HashSet<string> accept = new HashSet<string>();
             HashSet<string> exclude = new HashSet<string>();

--- a/Config/Config.cs
+++ b/Config/Config.cs
@@ -124,6 +124,10 @@ namespace FlexConfirmMail
                 }
             }
             accept.ExceptWith(exclude);
+            if (accept.Count == 0)
+            {
+                return "(?!)"; // means "never match to anything" for a blank list
+            }
             return $"({string.Join("|", accept.Select(ConvertWildCardToRegex))})";
         }
 

--- a/Config/Config.cs
+++ b/Config/Config.cs
@@ -95,21 +95,22 @@ namespace FlexConfirmMail
 
         public void RebuildPatterns()
         {
-            HashSet<string> trustedAddressList = GetHashSet(TrustedDomains.Where(_ => _.Contains("@")));
-            HashSet<string> trustedDomainList = GetHashSet(TrustedDomains.Where(_ => !_.Contains("@")));
-            HashSet<string> unsafeAddressList = GetHashSet(UnsafeDomains.Where(_ => _.Contains("@")));
-            HashSet<string> unsafeDomainList = GetHashSet(UnsafeDomains.Where(_ => !_.Contains("@")));
+            TrustedAddressesPattern = $"^{ConvertListToMatcherRegex(TrustedDomains.Where(_ => _.Contains("@")))}$";
+            TrustedDomainsPattern = $"^{ConvertListToMatcherRegex(TrustedDomains.Where(_ => !_.Contains("@")))}$";
+            UnsafeAddressesPattern = $"^{ConvertListToMatcherRegex(UnsafeDomains.Where(_ => _.Contains("@")))}$";
+            UnsafeDomainsPattern = $"^{ConvertListToMatcherRegex(UnsafeDomains.Where(_ => !_.Contains("@")))}$";
+            UnsafeFilesPattern = ConvertListToMatcherRegex(UnsafeFiles);
 
-            TrustedDomainsPattern = $"^({string.Join("|", trustedDomainList.Select(ConvertWildCardToRegex))})$";
-            TrustedAddressesPattern = $"^({string.Join("|", trustedAddressList.Select(ConvertWildCardToRegex))})$";
-            UnsafeDomainsPattern = $"^({string.Join("|", unsafeDomainList.Select(ConvertWildCardToRegex))})$";
-            UnsafeAddressesPattern = $"^({string.Join("|", unsafeAddressList.Select(ConvertWildCardToRegex))})$";
-            UnsafeFilesPattern = $"({string.Join("|", UnsafeFiles.Select(ConvertWildCardToRegex))})";
+            QueueLogger.Log($"TrustedAddressesPattern = {TrustedAddressesPattern}");
+            QueueLogger.Log($"TrustedDomainsPattern = {TrustedDomainsPattern}");
+            QueueLogger.Log($"UnsafeAddressesPattern = {UnsafeAddressesPattern}");
+            QueueLogger.Log($"UnsafeDomainsPattern = {UnsafeDomainsPattern}");
+            QueueLogger.Log($"UnsafeFilesPattern = {UnsafeFilesPattern}");
         }
 
-        private HashSet<string> GetHashSet(IEnumerable<string> list)
+        private static string ConvertListToMatcherRegex(IEnumerable<string> list)
         {
-            HashSet<string> ret = new HashSet<string>();
+            HashSet<string> accept = new HashSet<string>();
             HashSet<string> exclude = new HashSet<string>();
             foreach (string entry in list)
             {
@@ -119,11 +120,11 @@ namespace FlexConfirmMail
                 }
                 else
                 {
-                    ret.Add(entry);
+                    accept.Add(entry);
                 }
             }
-            ret.ExceptWith(exclude);
-            return ret;
+            accept.ExceptWith(exclude);
+            return $"({string.Join("|", accept.Select(ConvertWildCardToRegex))})";
         }
 
         private static string ConvertWildCardToRegex(string value)


### PR DESCRIPTION
This is a followup of #50.
The `-` operator should wok for unsafe file patterns.

Moreover, this contains a change to generate a "never match to anything" regex for blank list. Otherwise, any attachment will be alerted as "unsafe attachment file".
