### PR TITLE
Add a sub option to untrust unsafe recipients

### DIFF
--- a/Config/Config.cs
+++ b/Config/Config.cs
@@ -15,6 +15,7 @@ namespace FlexConfirmMail
         public bool MainSkipIfNoExt = false;
         public List<string> TrustedDomains;
         public List<string> UnsafeDomains;
+        public bool UntrustUnsafeRecipients = false;
         public List<string> UnsafeFiles;
         public bool SafeNewDomainsEnabled = true;
         public HashSet<ConfigOption> Modified;
@@ -78,6 +79,11 @@ namespace FlexConfirmMail
             if (other.Modified.Contains(ConfigOption.UnsafeDomains))
             {
                 UnsafeDomains.AddRange(other.UnsafeDomains);
+            }
+
+            if (other.Modified.Contains(ConfigOption.UntrustUnsafeRecipients))
+            {
+                UntrustUnsafeRecipients = other.UntrustUnsafeRecipients;
             }
 
             if (other.Modified.Contains(ConfigOption.UnsafeFiles))

--- a/Config/Const.cs
+++ b/Config/Const.cs
@@ -25,5 +25,6 @@ namespace FlexConfirmMail
         UnsafeDomains,
         UnsafeFiles,
         SafeNewDomainsEnabled,
+        UntrustUnsafeRecipients,
     }
 }

--- a/Config/Loader.cs
+++ b/Config/Loader.cs
@@ -185,6 +185,16 @@ namespace FlexConfirmMail
                 }
             }
 
+            if (key == "UntrustUnsafeRecipients")
+            {
+                if (ParseBool(val, out b))
+                {
+                    config.UntrustUnsafeRecipients = b;
+                    config.Modified.Add(ConfigOption.UntrustUnsafeRecipients);
+                    return true;
+                }
+            }
+
             return false;
         }
 

--- a/Dialog/ConfigDialog.xaml
+++ b/Dialog/ConfigDialog.xaml
@@ -64,7 +64,14 @@
             <TabItem Header="{x:Static resx:Resources.UnsafeDomains}">
                 <Grid>
                     <GroupBox Header="{x:Static resx:Resources.ConfigUnsafeDomains}" Margin="5,5,5,5">
-                        <TextBox x:Name="UnsafeDomains" AcceptsReturn="True"  Padding="1,3,1,3" Margin="3,3,3,3" VerticalScrollBarVisibility="Auto"></TextBox>
+                        <Grid>
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="*"/>
+                                <RowDefinition Height="Auto"/>
+                            </Grid.RowDefinitions>
+                            <TextBox Grid.Row="0" x:Name="UnsafeDomains" AcceptsReturn="True"  Padding="1,3,1,3" Margin="3,3,3,3" VerticalScrollBarVisibility="Auto"></TextBox>
+                            <CheckBox Grid.Row="1" x:Name="UntrustUnsafeRecipients" Margin="0,5,0,5" Content="{x:Static resx:Resources.UntrustUnsafeRecipients}" />
+                        </Grid>
                     </GroupBox>
                 </Grid>
             </TabItem>

--- a/Dialog/ConfigDialog.xaml.cs
+++ b/Dialog/ConfigDialog.xaml.cs
@@ -68,6 +68,7 @@ namespace FlexConfirmMail.Dialog
             {
                 UnsafeDomains.Text = Properties.Resources.UnsafeDomainsTemplate;
             }
+            UntrustUnsafeRecipients.IsChecked = _config.UntrustUnsafeRecipients;
 
             // UnsafeFiles
             if (_default.Modified.Contains(ConfigOption.UnsafeFiles))
@@ -156,6 +157,9 @@ namespace FlexConfirmMail.Dialog
             text += Serialize(ConfigOption.SafeNewDomainsEnabled,
                               SafeNewDomainsEnabled.IsChecked,
                               _default.SafeNewDomainsEnabled);
+            text += Serialize(ConfigOption.UntrustUnsafeRecipients,
+                              UntrustUnsafeRecipients.IsChecked,
+                              _default.UntrustUnsafeRecipients);
             return text;
         }
 

--- a/Dialog/MainDialog.xaml.cs
+++ b/Dialog/MainDialog.xaml.cs
@@ -118,30 +118,26 @@ namespace FlexConfirmMail.Dialog
             return ret;
         }
 
-        private bool IsTrustedDomain(string domain)
+        private bool IsTrustedRecipient(RecipientInfo recipient)
         {
             // Note: DOMAIN_EXCHANGE basically means "LegacyDN recipients whose
             // SMTP address we don't know". We assume they are internal users,
             // since it implies that they reside in Active Direcotry.
-            if (domain == RecipientInfo.DOMAIN_EXCHANGE)
+            if (recipient.Domain == RecipientInfo.DOMAIN_EXCHANGE)
             {
                 return true;
             }
 
             try
             {
-                return Regex.IsMatch(domain, _config.TrustedDomainsPattern, RegexOptions.IgnoreCase);
-            }
-            catch (RegexMatchTimeoutException) { }
-
-            return false;
-        }
-
-        private bool IsTrustedAddress(string address)
-        {
-            try
-            {
-                return Regex.IsMatch(address, _config.TrustedAddressesPattern, RegexOptions.IgnoreCase);
+                if (_config.UntrustUnsafeRecipients &&
+                    (Regex.IsMatch(recipient.Domain, _config.UnsafeDomainsPattern, RegexOptions.IgnoreCase) ||
+                     Regex.IsMatch(recipient.Address, _config.UnsafeAddressesPattern, RegexOptions.IgnoreCase)))
+                {
+                    return false;
+                }
+                return Regex.IsMatch(recipient.Domain, _config.TrustedDomainsPattern, RegexOptions.IgnoreCase) ||
+                       Regex.IsMatch(recipient.Address, _config.TrustedAddressesPattern, RegexOptions.IgnoreCase);
             }
             catch (RegexMatchTimeoutException) { }
 
@@ -154,7 +150,7 @@ namespace FlexConfirmMail.Dialog
 
             foreach (RecipientInfo info in recipients)
             {
-                if (IsTrustedDomain(info.Domain) || IsTrustedAddress(info.Address))
+                if (IsTrustedRecipient(info))
                 {
                     if (!seen.Contains(info.Domain))
                     {
@@ -172,7 +168,7 @@ namespace FlexConfirmMail.Dialog
 
             foreach (RecipientInfo info in list)
             {
-                if (!(IsTrustedDomain(info.Domain) || IsTrustedAddress(info.Address)))
+                if (!IsTrustedRecipient(info))
                 {
                     if (!seen.Contains(info.Domain))
                     {

--- a/Properties/Resources.Designer.cs
+++ b/Properties/Resources.Designer.cs
@@ -593,6 +593,15 @@ namespace FlexConfirmMail.Properties {
         }
         
         /// <summary>
+        ///   注意が必要なパターンに該当する宛先を「社内ではない」ものとして扱う に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        public static string UntrustUnsafeRecipients {
+            get {
+                return ResourceManager.GetString("UntrustUnsafeRecipients", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   注意が必要なファイル名 に類似しているローカライズされた文字列を検索します。
         /// </summary>
         public static string UnsafeFiles {

--- a/Properties/Resources.es.resx
+++ b/Properties/Resources.es.resx
@@ -208,6 +208,9 @@
 
 {1}</value>
   </data>
+  <data name="UntrustUnsafeRecipients" xml:space="preserve">
+    <value>Treat recipients as "not trusted" if they are matched to unsafe patterns.</value>
+  </data>
   <data name="UnsafeFilesPolicy" xml:space="preserve">
     <value># Archivos Inseguros ###
 # La politica de la empresa considera Los siguientes tipos de Archivos como inseguros.

--- a/Properties/Resources.ja.resx
+++ b/Properties/Resources.ja.resx
@@ -208,6 +208,9 @@
 
 {1}</value>
   </data>
+  <data name="UntrustUnsafeRecipients" xml:space="preserve">
+    <value>注意が必要なパターンに該当する宛先を「社内ではない」ものとして扱う</value>
+  </data>
   <data name="UnsafeFilesPolicy" xml:space="preserve">
     <value># 注意が必要なファイル名設定 ###
 # 組織設定により、注意が必要なファイル名として以下が指定されています。

--- a/Properties/Resources.resx
+++ b/Properties/Resources.resx
@@ -208,6 +208,9 @@
 
 {1}</value>
   </data>
+  <data name="UntrustUnsafeRecipients" xml:space="preserve">
+    <value>Treat recipients as "not trusted" if they are matched to unsafe patterns.</value>
+  </data>
   <data name="UnsafeFilesPolicy" xml:space="preserve">
     <value># Unsafe Files ###
 # The following keywords are considered unsafe by Group Policy.

--- a/Properties/Resources.zh.resx
+++ b/Properties/Resources.zh.resx
@@ -208,6 +208,9 @@
 
 {1}</value>
   </data>
+  <data name="UntrustUnsafeRecipients" xml:space="preserve">
+    <value>Treat recipients as "not trusted" if they are matched to unsafe patterns.</value>
+  </data>
   <data name="UnsafeFilesPolicy" xml:space="preserve">
     <value># 不安全的文件名 ###
 # 以下关键词被组策略认为是不安全的。

--- a/policy/FlexConfirmMailDefault.admx
+++ b/policy/FlexConfirmMailDefault.admx
@@ -101,6 +101,18 @@
         <multiText id="UnsafeDomains" valueName="UnsafeDomains"/>
       </elements>
     </policy>
+    <policy name="UntrustUnsafeRecipients" valueName="UntrustUnsafeRecipients"
+        displayName="$(string.UntrustUnsafeRecipients)" class="Machine"
+        key="SOFTWARE\Policies\FlexConfirmMail\Default">
+      <parentCategory ref="FlexConfirmMailDefault"/>
+      <supportedOn ref="SUPPORTED_NotSpecified"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
     <policy name="UnsafeFiles"
         displayName="$(string.UnsafeFiles)"
         explainText="$(string.UnsafeFiles_Explain)"

--- a/policy/en-US/FlexConfirmMailDefault.adml
+++ b/policy/en-US/FlexConfirmMailDefault.adml
@@ -18,6 +18,7 @@
       <string id="UnsafeFiles">Configure Unsafe files</string>
       <string id="UnsafeFiles_Explain">Set the list of keywords to show an "unsafe filename" warning. Wildcards (* and ?) are available.</string>
       <string id="SafeNewDomainsEnabled">Confirm when any recipients with domains different from any existing recipients are added</string>
+      <string id="UntrustUnsafeRecipients">Treat recipients as "not trusted" if they are matched to unsafe patterns.</string>
     </stringTable>
     <presentationTable>
       <presentation id="CountSeconds">

--- a/policy/es-ES/FlexConfirmMailDefault.adml
+++ b/policy/es-ES/FlexConfirmMailDefault.adml
@@ -17,6 +17,8 @@
       <string id="UnsafeDomains_Explain">Configure lista de dominios y direcciones que muestre una advertencia de "destinatario no seguro".</string>
       <string id="UnsafeFiles">Configurar archivos inseguros</string>
       <string id="UnsafeFiles_Explain">Configure lista de palabras clave que muestre una advertencia "nombre de archivo no seguro"</string>
+      <string id="SafeNewDomainsEnabled">Confirm when any recipients with domains different from any existing recipients are added</string>
+      <string id="UntrustUnsafeRecipients">Treat recipients as "not trusted" if they are matched to unsafe patterns.</string>
     </stringTable>
     <presentationTable>
       <presentation id="CountSeconds">

--- a/policy/ja-JP/FlexConfirmMailDefault.adml
+++ b/policy/ja-JP/FlexConfirmMailDefault.adml
@@ -18,6 +18,7 @@
       <string id="UnsafeFiles">注意が必要なファイル名設定</string>
       <string id="UnsafeFiles_Explain">添付ファイルに含まれる場合に警告する注意ワードを指定します。指定にはワイルドカード（*および?）を使用可能です。</string>
       <string id="SafeNewDomainsEnabled">返信の宛先に今まで含まれていなかったドメインのアドレスが追加された場合に警告する</string>
+      <string id="UntrustUnsafeRecipients">注意が必要なパターンに該当する宛先を「社内ではない」ものとして扱う</string>
     </stringTable>
     <presentationTable>
       <presentation id="CountSeconds">

--- a/policy/zh-CN/FlexConfirmMailDefault.adml
+++ b/policy/zh-CN/FlexConfirmMailDefault.adml
@@ -18,6 +18,7 @@
       <string id="UnsafeFiles">设置不安全的文件名</string>
       <string id="UnsafeFiles_Explain">为附件设置警告关键字。 Wildcards (* and ?) are available.</string>
       <string id="SafeNewDomainsEnabled">Confirm when any recipients with domains different from any existing recipients are added</string>
+      <string id="UntrustUnsafeRecipients">Treat recipients as "not trusted" if they are matched to unsafe patterns.</string>
     </stringTable>
     <presentationTable>
       <presentation id="CountSeconds">


### PR DESCRIPTION
Trusted recipients are still treated as trusted, even if they are detected as "unsafe". This change introduces a new option to tread such unsafe recipients as "untrusted". The new behavior breaks backward compatibility, so it is optional and disabled by default.
