### PR TITLE
build.yaml: Update upload-artifact

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Make Installer
         run: iscc.exe FlexConfirmMail.iss
       - name: Upload Installer
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Installer
           path: dest/*.exe


### PR DESCRIPTION
`upload-artifact@v3` is obsoleted, we must use `upload-artifact@v4` 